### PR TITLE
Release/0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+
+# Created by https://www.gitignore.io/api/windows,visualstudiocode,linux
+# Edit at https://www.gitignore.io/?templates=windows,visualstudiocode,linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/windows,visualstudiocode,linux
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,6 @@ jobs:
     - stage: Prepare
       script:
         - echo "~~ Build Started ~~"
-        # Setup exit behavior for scripts
-        - set -Eeo pipefail # (-) is enable (+) is disable
         # Making all scripts executable
         - chmod 755 ./scripts/envinfo.sh
         # Printing important diagnostics env vars
@@ -111,8 +109,6 @@ jobs:
     - stage: Deploy
       script:
         - echo "~~ Deploy Started ~~"
-        # Setup exit behavior for scripts
-        - set -Eeo pipefail # (-) is enable (+) is disable
         # Making all scripts executable
         - chmod 755 ./scripts/envinfo.sh
         # Printing important diagnostics env vars

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: bionic
 
+os: linux
+sudo: required
+language: c
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,12 +95,16 @@ jobs:
         # Making all scripts executable
         - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
+        - EXIT_CODE=0
         - bash ./scripts/envinfo.sh > envinfo.txt
-        - EXIT_CODE=$?
+        - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
         - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
         # Execute main script for this stage
+        - EXIT_CODE=0
         - bash ./scripts/build.sh
+        - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
+        - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         #  Announcing Stage Ending
         - echo "~~ Build Success ~~"
 
@@ -114,12 +118,16 @@ jobs:
         # Making all scripts executable
         - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
+        - EXIT_CODE=0
         - bash ./scripts/envinfo.sh > envinfo.txt
-        - EXIT_CODE=$?
+        - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
         - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
         # Execute main script for this stage
+        - EXIT_CODE=0
         - bash ./scripts/deploy.sh
+        - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
+        - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         #  Announcing Stage Ending
         - echo "~~ Deploy Success ~~"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,8 @@ jobs:
         - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
+        - EXIT_CODE=$?
+        - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
         # Execute main script for this stage
         - bash ./scripts/build.sh
@@ -113,6 +115,8 @@ jobs:
         - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
+        - EXIT_CODE=$?
+        - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
         # Execute main script for this stage
         - bash ./scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ dist: bionic
 services:
   - docker
 
+# @@ Travis Dashboard Variables Required to Run Project !!
+# DKRHUB_USER="Dockerhub username here"
+# DKRHUB_PASS="Dockerhub password here"
+# DKRHUB_PROJ="Name of dockerhub project"
+# DKRHUB_REPO="${DKRHUB_USER}/${DKRHUB_PROJ}""
+# AUTH_EMAIL="Email of author for notifications"
+
 env:
   global:
     - COMMIT_SHA=${TRAVIS_COMMIT::8}

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,9 @@ jobs:
         - cat envinfo.txt
 
         - echo "~~ Deploy Success ~~"
+notifications:
+  email:
+    recipients:
+      - ${AUTH_EMAIL}
+    on_success: never
+    on_failure: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,8 @@ jobs:
         - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
         - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
+        - docker --version
+        - cat docker-info.txt
         # Execute main script for this stage
         - EXIT_CODE=0
         - bash ./scripts/build.sh
@@ -123,6 +125,8 @@ jobs:
         - echo "EXIT_CODE:= $EXIT_CODE" && cat fnresult.txt && source fnresult.txt && rm -rf fnresult.txt && echo "EXIT_CODE:= $EXIT_CODE"
         - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
         - cat envinfo.txt
+        - docker --version
+        - cat docker-info.txt
         # Execute main script for this stage
         - EXIT_CODE=0
         - bash ./scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
       script:
         - echo "~~ Build Started ~~"
         # Making all scripts executable
-        - chmod 755 ./scripts/envinfo.sh
+        - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
         - cat envinfo.txt
@@ -110,7 +110,7 @@ jobs:
       script:
         - echo "~~ Deploy Started ~~"
         # Making all scripts executable
-        - chmod 755 ./scripts/envinfo.sh
+        - chmod 755 ./scripts/*.sh
         # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
         - cat envinfo.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
+# Using travis Ubuntu build environment as it had many tools installed: git, docker, python
+# - Using ubuntu based build agent will allow ubuntu scripts & commands to be used in build steps
+# - Like I can freely use `sudo apt-get install xyz` to install tools xyz or even do a `pip install`
+os: linux
 dist: bionic
 
-os: linux
+# Root access into build agent for special commands
 sudo: required
-language: c
 
+# Choosing default python build env. as common to all
+language: python
+
+# Services containers required in project: databases, docker
 services:
+  # Required to use Docker-in-Docker for building Dockerfile
   - docker
 
 # @@ Travis Dashboard Variables Required to Run Project !!
@@ -13,14 +21,34 @@ services:
 # DKRHUB_PROJ="Name of dockerhub project"
 # DKRHUB_REPO="${DKRHUB_USER}/${DKRHUB_PROJ}""
 # AUTH_EMAIL="Email of author for notifications"
-
+#
 env:
+  # Global environment variables (constants and computed)
   global:
+    # Repository commit SHA in short (first eight characters are enough)
     - COMMIT_SHA=${TRAVIS_COMMIT::8}
+    # Set noninteractive debian front-end so that ubuntu work with no prompts
+    - DEBIAN_FRONTEND=noninteractive
+  # Travis will repeat build with each row in matrix and populate env vars
+  # mentioned here. This will be used to create multiple images from Dockerfile
+  matrix:
+    - UBUNTU_VER=18.04
 
+# Installation of additional tools into travis ci-agent for build, test and deploy
+install:
+  - echo "^^^ Nothing to Install yet on Travis CI Agent ^^^"
+
+# Build Stages for the Project
+# - Stages runs sequentially and house multiple parallel jobs (jobs may allow_faliure)
+# - It's natural to have build conditions at Stage level to avoid repetitions in jobs
+# - Travis has exception of not able to store artifacts (so to pass them in stages
+#   you've to use owns server. We shall be pushing build images to Docker Registry
+#   & those shall be pulled in Deploy stage)
+# - It's a simple project thus having only 2 stages: Prepare & Deploy
 stages:
   # STAGE#1: Build & Test Stage
-  # - Enable for master, hotfix, bugfix, release, builds, tests, topic, pull_request, or master-tags (v*, tmp* or qa*)
+  # - Stage for multiple jobs: pre-build (lint), build and test. Once done generates tested artifact (staging release)
+  # - Enable only for master, hotfix, bugfix, release, builds, tests, topic, pull_request, or master-tags (v*, tmp* or qa*)
   - name: "Prepare"
     if: |
       ((branch = master) AND (tag IS blank) AND (type != pull_request)) OR \
@@ -33,35 +61,74 @@ stages:
       type = pull_request OR \
       ((tag =~ /^(v|tmp|qa)(\d+.)(\d+.)(\d+)$/) AND (branch = master))
 
-  # STAGE#2: Deploy to Prod Stage
-  # - Enable for master, or master-tags (only v*)
+  # STAGE#2: Deployment to Production
+  # - Stage representing all - Staging, QA, UAT, & Prod. Will receive tested artifact from build and pushes it to Dockerhub
+  # - Enable for master, or master-tags (only v*). You can't deploy from any other branch or tag into production zone
   - name: "Deploy"
     if: |
       ((branch = master) AND (tag IS blank) AND (type != pull_request)) OR \
       ((tag =~ /^(v)(\d+.)(\d+.)(\d+)$/) AND (branch = master) AND (type != pull_request))
 
+# Prep Stage: (Build+Test)
+# 1. Generates dockerfile from template as per 'matrix' to build particular ubuntu
+# 2. Build's dockerfile and generate docker-image artifact inside travis ci-node
+# 3. Test generated docker-image in ci-node for execution for failure or success
+# 4. If build succeeds pushes image to dockerhub for deployment (only master & tags)
+#    - This image will be tagged as build SHA (created on_success)
+#    - Deploy stage will pull and test image from dockerhub then tag it
+#      (it also removes SHA tags from dockerhub using dockerhub API)
+
+#Deploy Stage: Deploy tested docker-image to dockerhub for public usage
+
+# Build Jobs for the Project
+# - We've one job per stage defined next, totalling two: Prepare & Deploy
+#
 jobs:
   include:
+    #---------------------------------------------- PREPARE ----------------------------------------------
+    # TASKS
+    # - Use build.sh to build docker-image from Dockerfile
+    # - Prepare stage  [LINT, BUILD, GENERATE, TEST]
     - stage: Prepare
       script:
-        - set -Eeo pipefail
+        - echo "~~ Build Started ~~"
+        # Setup exit behavior for scripts
+        - set -Eeo pipefail # (-) is enable (+) is disable
+        # Making all scripts executable
         - chmod 755 ./scripts/envinfo.sh
+        # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
         - cat envinfo.txt
-
+        # Execute main script for this stage
+        - bash ./scripts/build.sh
+        #  Announcing Stage Ending
         - echo "~~ Build Success ~~"
 
+    #---------------------------------------------- DEPLOY ----------------------------------------------
+    # TASKS
+    # - Use deploy.sh to publish docker-image to Dockerhub
+    # - Deploy stage [TEST-IMG, TEST-DEPLOY, DEPLOY & VERIFY]
     - stage: Deploy
       script:
-        - set -Eeo pipefail
+        - echo "~~ Deploy Started ~~"
+        # Setup exit behavior for scripts
+        - set -Eeo pipefail # (-) is enable (+) is disable
+        # Making all scripts executable
         - chmod 755 ./scripts/envinfo.sh
+        # Printing important diagnostics env vars
         - bash ./scripts/envinfo.sh > envinfo.txt
         - cat envinfo.txt
-
+        # Execute main script for this stage
+        - bash ./scripts/deploy.sh
+        #  Announcing Stage Ending
         - echo "~~ Deploy Success ~~"
+
+# Configuration of EMail Notifications
+# on_success: required to know as deployment is made
+# on_failure: not requires as will bomb email address
 notifications:
   email:
     recipients:
       - ${AUTH_EMAIL}
-    on_success: never
+    on_success: always
     on_failure: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,26 @@ env:
     - COMMIT_SHA=${TRAVIS_COMMIT::8}
 
 stages:
+  # STAGE#1: Build & Test Stage
+  # - Enable for master, hotfix, bugfix, release, builds, tests, topic, pull_request, or master-tags (v*, tmp* or qa*)
   - name: "Prepare"
+    if: |
+      ((branch = master) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^hotfix\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^bugfix\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^release\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^builds\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^tests\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((branch =~ /^topic\/(.*)/) AND (tag IS blank) AND (type != pull_request)) OR \
+      type = pull_request OR \
+      ((tag =~ /^(v|tmp|qa)(\d+.)(\d+.)(\d+)$/) AND (branch = master))
+
+  # STAGE#2: Deploy to Prod Stage
+  # - Enable for master, or master-tags (only v*)
   - name: "Deploy"
+    if: |
+      ((branch = master) AND (tag IS blank) AND (type != pull_request)) OR \
+      ((tag =~ /^(v)(\d+.)(\d+.)(\d+)$/) AND (branch = master) AND (type != pull_request))
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+dist: bionic
+
+services:
+  - docker
+
+env:
+  global:
+    - COMMIT_SHA=${TRAVIS_COMMIT::8}
+
+stages:
+  - name: "Prepare"
+  - name: "Deploy"
+
+jobs:
+  include:
+    - stage: Prepare
+      script:
+        - set -Eeo pipefail
+        - chmod 755 ./scripts/envinfo.sh
+        - bash ./scripts/envinfo.sh > envinfo.txt
+        - cat envinfo.txt
+
+        - echo "~~ Build Success ~~"
+
+    - stage: Deploy
+      script:
+        - set -Eeo pipefail
+        - chmod 755 ./scripts/envinfo.sh
+        - bash ./scripts/envinfo.sh > envinfo.txt
+        - cat envinfo.txt
+
+        - echo "~~ Deploy Success ~~"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Attach REQUEST.md with full details of changes made and where, this includes new environment
+   variables, exposed ports, useful file locations, container parameters etc. with funcationality change in separate section
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/
+
+### Liabilities
+
+Again no liabilities to owner in any form, do post change pull-request at your own free-will with complete sole ownership of liabilities (if any) generated post same.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Base image for docker image genration
+FROM ubuntu:18.04 AS sacn-ubuntu-build-agent
+
+# Labelling of the image (author, version)
+LABEL maintainer="SACn <no-reply@unknown.com>"
+ENV IMG_AUTH="SACn <no-reply@unknown.com>"
+LABEL name="sacn-ubuntu-build-agent"
+ENV IMG_NAME "sacn-ubuntu-build-agent"
+LABEL version="0.0.0"
+ENV IMG_VER="0.0.0"
+
+# Set packages install in noninteractive mode.
+ENV DEBIAN_FRONTEND noninteractive
+RUN export DEBIAN_FRONTEND=noninteractive
+
+# --------------- Launch Startup Script ---------------
+# Using `docker run --ti` you can see the output log of script
+#
+COPY startup.sh /startup.sh
+RUN chmod 755 /startup.sh
+CMD [ "/bin/bash", "-c", "/startup.sh" ]

--- a/History.md
+++ b/History.md
@@ -2,6 +2,11 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- FIX: As per common build errors in travis [my build fails unexpectedly](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly)
+  - We can't use `set -e` either directly in your `.travis.yml`, or `sourceing` a script
+  - Thus we've removed line `set -Eeo pipefail # (-) is enable (+) is disable`
+  - Note that using set -e in external scripts does not cause this problem
+  - Thus keeping line in `build.sh`, `deploy.sh`, but not in `library.sh` as this could be sources anywhere
 - 000: Created basic 2 stage `.travis.yml` to simulate prepare and deploy.
   - This is a good starting point for first alpha release `0.0.0`
   - In `0.0.0` nothing will be built or deployed, just to test CI cycle

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- ADD: `docs/gitflow-guide.md` file for theory on Gitflow with `Quick CI Setup Checklist`
 - MOD: `.travis.yml` with `os: linux`, `sudo: required`, `language: c` to make cfg complete
 - MOD: `.travis.yml` with comments for env var needed in Travis Dashboard to run Project.
 - MOD: README.md modified with quick links to important files like `.travis.yml`

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- MOD: `.travis.yml` with `os: linux`, `sudo: required`, `language: c` to make cfg complete
 - MOD: `.travis.yml` with comments for env var needed in Travis Dashboard to run Project.
 - MOD: README.md modified with quick links to important files like `.travis.yml`
 - FTR: Added markdown in README.md for Travis build status of master branch on Github project

--- a/History.md
+++ b/History.md
@@ -1,0 +1,10 @@
+# 0.0.0 / 2019-12-13
+
+Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
+
+- MOD: Description of project in README.md for next Alpha Version (0.0.0)
+- ADD: Basic 2 stage travis configuration (.travis.yml) to print env vars using BASH script
+- ADD: BASH script to print travis environment variables & export dummy data
+- ADD: Vanilla ubuntu:1804 based docker image with `Hello World`
+- ADD: CONTRIBUTING.md file for contributions making process for this repository.
+- ADD: .gitignore file for arresting commit of windows, vscode and linux trash to git repo.

--- a/History.md
+++ b/History.md
@@ -2,6 +2,11 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- FIX: `.travis.yml` to check error code of bash scripts just after call
+  ```
+      - EXIT_CODE=$?
+      - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
+  ```
 - FIX: Not using `if [[ ... ]]` for conditions in `./scripts/envinfo.sh`. Double brackets to be used everywhere
   - Inside `travis.yml` as well as any external script called like `./scripts/envinfo.sh`.
 - FIX: Making all scripts executable was not using `*.sh` corrected as `chmod 755 ./scripts/*.sh` in `.travis.yml`
@@ -29,3 +34,7 @@ Added code to generate docker image of **Ubuntu with essentials like git, rar et
 - ADD: Vanilla ubuntu:1804 based docker image with `Hello World`
 - ADD: CONTRIBUTING.md file for contributions making process for this repository.
 - ADD: .gitignore file for arresting commit of windows, vscode and linux trash to git repo.
+
+```
+
+```

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- MOV: Moved export of SHARED variables and functions from `envinfo.sh` to `library.sh`
 - ADD: `docs/gitflow-guide.md` file for theory on Gitflow with `Quick CI Setup Checklist`
 - MOD: `.travis.yml` with `os: linux`, `sudo: required`, `language: c` to make cfg complete
 - MOD: `.travis.yml` with comments for env var needed in Travis Dashboard to run Project.

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- FIX: Making all scripts executable was not using `*.sh` corrected as `chmod 755 ./scripts/*.sh` in `.travis.yml`
 - ADD: File where file based environment variables can be placed for `source ./scripts/env-init.sh`
 - FIX: As per common build errors in travis [my build fails unexpectedly](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly)
   - We can't use `set -e` either directly in your `.travis.yml`, or `sourceing` a script

--- a/History.md
+++ b/History.md
@@ -3,10 +3,10 @@
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
 - FIX: `.travis.yml` to check error code of bash scripts just after call
-  ```
-      - EXIT_CODE=$?
-      - if [[ $EXIT_CODE -ne 0 ]]; then echo "ERR! (EXIT_CODE=$EXIT_CODE)" && set +e && exit $EXIT_CODE; fi
-  ```
+  - Using `EXIT_CODE=$?` with `if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi` in `.travis.yml` does not work. Travis always makes `EXIT_CODE=1` on using `EXIT_CODE=$?` after call of bash script in `.travis.yml`
+  - Now storing return status of function in file `fnresult.txt` using command `echo "export EXIT_CODE=$?" > fnresult.txt` and sourcing it in `.travis.yml` to get function results back
+    - This is working fine, also pushed `export ENV_LOADED=1` to `fnresult.txt` for demonstration that environment variables can be exchanged via intermediate file from bash script to `.travis.yml`
+- FIX: In `export HELLO_VARIABLE="! SACn Welcomes You [scripts\env-init.sh]!"` used name of file to differentiate from where this export is made. Also modified `hello_world` to print argument `$`
 - FIX: Not using `if [[ ... ]]` for conditions in `./scripts/envinfo.sh`. Double brackets to be used everywhere
   - Inside `travis.yml` as well as any external script called like `./scripts/envinfo.sh`.
 - FIX: Making all scripts executable was not using `*.sh` corrected as `chmod 755 ./scripts/*.sh` in `.travis.yml`

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- MOD: `.travis.yml` with comments for env var needed in Travis Dashboard to run Project.
 - MOD: README.md modified with quick links to important files like `.travis.yml`
 - FTR: Added markdown in README.md for Travis build status of master branch on Github project
 - FTR: Send email notifications to travis env var# `${AUTH_EMAIL}` in travis configuration

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- FTR: Added markdown in README.md for Travis build status of master branch on Github project
 - FTR: Send email notifications to travis env var# `${AUTH_EMAIL}` in travis configuration
 - FTR: Travis build-configuration conditions for Gtiflow model wrt simple 2 stage deployment
 - ADD: Made History.md using `git changelog` and edited with details about next 0.0.0 version

--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- FIX: Not using `if [[ ... ]]` for conditions in `./scripts/envinfo.sh`. Double brackets to be used everywhere
+  - Inside `travis.yml` as well as any external script called like `./scripts/envinfo.sh`.
 - FIX: Making all scripts executable was not using `*.sh` corrected as `chmod 755 ./scripts/*.sh` in `.travis.yml`
 - ADD: File where file based environment variables can be placed for `source ./scripts/env-init.sh`
 - FIX: As per common build errors in travis [my build fails unexpectedly](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly)

--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- ADD: Printing details of docker environment from `scripts\envinfo.sh` in file `docker-info.txt`
+  - File content is displayed in `.travis.yml` for diagnostics of docker
 - FIX: `.travis.yml` to check error code of bash scripts just after call
   - Using `EXIT_CODE=$?` with `if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi` in `.travis.yml` does not work. Travis always makes `EXIT_CODE=1` on using `EXIT_CODE=$?` after call of bash script in `.travis.yml`
   - Now storing return status of function in file `fnresult.txt` using command `echo "export EXIT_CODE=$?" > fnresult.txt` and sourcing it in `.travis.yml` to get function results back
@@ -34,7 +36,3 @@ Added code to generate docker image of **Ubuntu with essentials like git, rar et
 - ADD: Vanilla ubuntu:1804 based docker image with `Hello World`
 - ADD: CONTRIBUTING.md file for contributions making process for this repository.
 - ADD: .gitignore file for arresting commit of windows, vscode and linux trash to git repo.
-
-```
-
-```

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- ADD: File where file based environment variables can be placed for `source ./scripts/env-init.sh`
 - FIX: As per common build errors in travis [my build fails unexpectedly](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly)
   - We can't use `set -e` either directly in your `.travis.yml`, or `sourceing` a script
   - Thus we've removed line `set -Eeo pipefail # (-) is enable (+) is disable`

--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- FTR: Travis build-configuration conditions for Gtiflow model wrt simple 2 stage deployment
+- ADD: Made History.md using `git changelog` and edited with details about next 0.0.0 version
 - MOD: Description of project in README.md for next Alpha Version (0.0.0)
 - ADD: Basic 2 stage travis configuration (.travis.yml) to print env vars using BASH script
 - ADD: BASH script to print travis environment variables & export dummy data

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- FTR: Send email notifications to travis env var# `${AUTH_EMAIL}` in travis configuration
 - FTR: Travis build-configuration conditions for Gtiflow model wrt simple 2 stage deployment
 - ADD: Made History.md using `git changelog` and edited with details about next 0.0.0 version
 - MOD: Description of project in README.md for next Alpha Version (0.0.0)

--- a/History.md
+++ b/History.md
@@ -1,7 +1,10 @@
 # 0.0.0 / 2019-12-13
 
-Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
+Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)
 
+- 000: Created basic 2 stage `.travis.yml` to simulate prepare and deploy.
+  - This is a good starting point for first alpha release `0.0.0`
+  - In `0.0.0` nothing will be built or deployed, just to test CI cycle
 - MOV: Moved export of SHARED variables and functions from `envinfo.sh` to `library.sh`
 - ADD: `docs/gitflow-guide.md` file for theory on Gitflow with `Quick CI Setup Checklist`
 - MOD: `.travis.yml` with `os: linux`, `sudo: required`, `language: c` to make cfg complete

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
 
+- MOD: README.md modified with quick links to important files like `.travis.yml`
 - FTR: Added markdown in README.md for Travis build status of master branch on Github project
 - FTR: Send email notifications to travis env var# `${AUTH_EMAIL}` in travis configuration
 - FTR: Travis build-configuration conditions for Gtiflow model wrt simple 2 stage deployment

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This repository contains code to generate docker image of **Ubuntu with essentia
 - Making Tech. Contributions : [CONTRIBUTING.md](CONTRIBUTING.md)
 - Licensing for the Project : [LICENSE](LICENSE)
 - Travis CI Build Configuration: [.travis.yml](.travis.yml)
-- Printing of Travis Env. Vars : [scripts\envinfo.sh](scripts\envinfo.sh)
+- Printing of Travis Env. Vars : [scripts/envinfo.sh](scripts/envinfo.sh)
 - History of Changes (Detailed): [History.md](History.md)
+- Quick CI Setup & Gitflow Theory : [docs/gitflow-guide.md](docs/gitflow-guide.md)
 
 ## Travis Dashboard Variables Required
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ This repository contains code to generate docker image of **Ubuntu with essentia
 - Travis CI Build Configuration: [.travis.yml](.travis.yml)
 - Printing of Travis Env. Vars : [scripts\envinfo.sh](scripts\envinfo.sh)
 - History of Changes (Detailed): [History.md](History.md)
+
+## Travis Dashboard Variables Required
+
+In order to build the project in Travis CI following envirnment variables to be setup using it's project dashboard
+
+- DKRHUB_USER="Dockerhub username here
+- DKRHUB_PASS="Dockerhub password here
+- DKRHUB_PROJ="Name of dockerhub project
+- DKRHUB_REPO='DKRHUB_USER/DKRHUB_PROJ'
+- AUTH_EMAIL="Email of author for notifications

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Project
 
+[![Build Status](https://travis-ci.com/sachin-gupta/dkrhub-cinode-ubu.svg?branch=master)](https://travis-ci.com/sachin-gupta/dkrhub-cinode-ubu)
+
 This repository contains code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# dkrhub-cinode-ubu
-Generates dockerhub image of ubuntu with minimal essentials docker, docker-compose, openssh, git etc. to be used as build agent.
+# Project
+
+This repository contains code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 [![Build Status](https://travis-ci.com/sachin-gupta/dkrhub-cinode-ubu.svg?branch=master)](https://travis-ci.com/sachin-gupta/dkrhub-cinode-ubu)
 
 This repository contains code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github.
+
+- Making Tech. Contributions : [CONTRIBUTING.md](CONTRIBUTING.md)
+- Licensing for the Project : [LICENSE](LICENSE)
+- Travis CI Build Configuration: [.travis.yml](.travis.yml)
+- Printing of Travis Env. Vars : [scripts\envinfo.sh](scripts\envinfo.sh)
+- History of Changes (Detailed): [History.md](History.md)

--- a/docs/build-table.md
+++ b/docs/build-table.md
@@ -1,0 +1,40 @@
+A generic Gitflow table to setup builds, tests and deployments follows:
+
+| Type   | REFs                 | Build | Test |  Review   | Staging<sup>4</sup> | QA<sup>5</sup> | UAT, PROD | Remarks                |
+| :----- | :------------------- | :---: | :--: | :-------: | :-----------------: | :------------: | :-------: | :--------------------- |
+| Branch | master               |  yes  | yes  |    no     |      auto-inst      |       no       |    no     | <sup>1</sup>           |
+| Tag    | tag (v\*) [master]   |   -   |  -   |    no     |          -          |    man-inst    | man-inst  | <sup>2</sup>           |
+| Branch | hotfix/\*            |  yes  | yes  | auto-inst |         no          |       no       | man-inst  | <sup>3</sup>, Raise PR |
+| Branch | bugfix/\*            |  yes  | yes  | auto-inst |         no          |       no       |    no     | Raise PR               |
+| Branch | release/\*           |  yes  | yes  |    no     |         no          |       no       |    no     | Raise PR               |
+| Branch | features/\*          |  no   |  no  |    no     |         no          |       no       |    no     | PR Not Allowed         |
+| Branch | builds/\*            |  yes  |  no  |    no     |         no          |       no       |    no     | PR Not Allowed         |
+| Branch | tests/\*             |  yes  | yes  |    no     |         no          |       no       |    no     | PR Not Allowed         |
+| Branch | topic/\*             |  yes  | yes  |    yes    |         no          |       no       |    no     | PR Not Allowed         |
+| Pull   | pull-requests        |  yes  | yes  |    no     |         no          |       no       |    no     | Don't Approve Failed   |
+| Tag    | tag (tmp\*) [master] |   -   |  -   |    no     |          -          |    man-inst    |    no     | <sup>2</sup>           |
+| Tag    | tag (\*)             |  no   |  no  |    no     |         no          |       no       |    no     | no                     |
+
+1. Master must be built and tested to ensure it's always deployable as per Gitflow. Moreover ONLY master commits can be deployed apart from it's `v*.*.*` tags (automatically up to staging and rest manual). Inclusion of master commit deployment also makes manager happy.
+
+2. Master tags (v\*) are placed to start promote to QA onwards, and should not be built (they should use earlier artifact id re-deployed, otherwise tags have artifact when you tag master SHA to promote it from staging to quality.
+
+   - Master tags (tmp* or qa*) are not for clients but maybe needed by managers for say monthly internal sub-releases to be deployable on QA again without re-build (as artifact of master is already there)
+
+3. Hotfix can't go full QA thus are risky too, and few people would like you to delay with raising PRs and promoting hotfixes. Hotfixes should not enter staging as auto-installed by master. One can after quick checking hotfix in review deploy it to client UAT then to PROD.
+
+   - If things fail PROD can be rolled back and master is intact. If hotfix succeeds then make next release PR with master (it is not necessary to send this to client) - this can remain on master/staging and await merging by next feature in line on new PR.
+
+   - Hotfix should not go to production area (staging onwards is for master) so it should be deployed to review area before a PR is put-up for master-merge and tagging (promotion to QA/UAT/PROD).
+
+4. Staging ?: Everything from Staging onwards: **_Test with production database copy, against production services, in a isolated-production (*or non-production*) environment. This will ensure that your database scripts will not fuss your production database_**
+
+   - Intended for previously defined pilot or internal _in-house users only_
+   - Not exposed to full or partial production user groups
+   - Automatically deployed from master only using PRs (many times a day) to keep everybody aligned.
+   - Typically torn-down or removed after production deployment
+   - Sometimes not a complete 1:1with production (_can't replace it _)
+
+5. QA ?: Manager pushes final releases from master after tagging it with next release number like `v*.*.*` as per delivery schedule. Then QA lead needs to approval after full-testing of new features and old-features. Once approved, manager promotes release to client (UAT then PROD). Usually clients are not given access to this as many internal non-delivered items can also being tested by QA like future plan releases.
+
+6. UAT + PROD ?: Actually client access, anything here is considered live and on-prod changes could be occurring that needs to be updated to UAT (on_change immediate)

--- a/docs/gitflow-guide.md
+++ b/docs/gitflow-guide.md
@@ -1,0 +1,201 @@
+# Gitflow:= Travis +Gitlab
+
+Here presents a short summary about concepts and choices for achieving pull-request based Gitflow development using Travis and Github. Concepts here will help one understand and setup CI for gitflow development strategy with minimal build loads on CI Server (`builds-minimization`)
+
+**Table Of Contents:**
+
+[TOC]
+
+## Quick CI Setup Checklist
+
+Same can be applied to any CI system apart from Travis, However - way to apply may change. For example Gitlab CI may not have these settings in dashboard and you've to find a workaround.
+
+- Setup CI settings in dashboard for:
+  - `Build Pushed Branches: Yes` and as per overriding conditions in `.travis.yml`
+  - `Build Pull-Requests: Yes` and as per overriding conditions in `.travis.yml`
+  - `Auto-Cancel Queued Builds: Yes` to reduce number of builds on build server
+  - `Auto-Cancel Pull-request Builds: No` to keep old PRs active with no need to `Re-PR`
+- Setup CI for automatic build of PRs as:
+  - `merge-builds` for `OPENED` PRs excluding: `DRAFT` & `CLOSED`
+  - `merge-builds` for `New Commits on OPENED PRs` only.
+- Setup to skip any commit with message having `[skip travis] ...`
+- Setup desired custom build conditions based on
+  - `$TRAVIS_BRANCH`: name of the branch
+  - `$TRAVIS_TAG`: name of the tag otherwise blank
+  - `$TRAVIS_PULL_REQUEST`: true or false
+- Setup bash script for proper error throwing:
+  - With suitable options from: `set Eeuox pipefail` with `set +` or `set -`
+  - Capture exit status anytime using `EXIT_STAT=$?` after a command
+  - Test exit status for actions `if [[ $EXIT_STAT != 0 ]]; then echo "Error ..." && exit $EXIT_STAT; fi`
+  - Simply exit using `exit $EXIT_STAT` or `exit -100` as per liking
+- For environment variables or variables use `export VAR=value` otherwise they become local variable to the .sh script and will not be transferred to CI process
+- To export functions globally use `export -f docker_build_push()` syntax
+- A generic Gitflow table for quick condition setup in: [docs\build-table.md](docs\build-table.md)
+
+## Achieving Containerized DEVOPs
+
+Should read [Flawless Releases with Continuous Deployment and Docker](https://hackernoon.com/continuous-deployment-of-a-python-flask-application-with-docker-and-semaphore-b21aq12v1). Why you need this ??
+
+- Consistency : Production and development environments are equal.
+- Portability : Fewer dependencies with the underlying OS; the same image can be deployed on any cloud provider.
+- Overhead : Better performance than virtual machines, may use alpine on production and ubuntu based docker for dev.
+- Divide and conquer: Distribute services among different containers (Micro-services & Scaling)
+- Ready Offerings: 100's of ready containerized tools and server (no need to learn install process, tools remains same for all in organization)
+- DIY Images: Create own images for dev-envs, libs, compiler / build-tools, test-tools, prod-servers for entire organization or project level (achieving zero parity)
+  Docker introduces a new variable to the equation: the app must be baked into the container image, then correctly deployed. In addition, setting up a test environment can prove more challenging. In this semaphore, at very high level:
+- Continuous Integration: Build and test the app image.
+  - Create/update on merge request
+    - Build image
+    - Push to container registry using commit SHA
+    - Run parallel tests
+    - Tag image with branch name
+  - Push/merge to master
+    - Build image (would be great to re-use image if same SHA)
+    - Run parallel tests (would be great to skip if same SHA)
+    - Tag image with latest (or staging)
+    - Deploy to staging
+- Continuous Deployment: Send the image to Heroku etc to run online with scaling.
+  - Tag - Pull image for SHA (would be nice to re-build if needed for some reason) - Tag image with new tag - Deploy to production
+    Typical docker based workflow may be devised as, see [kubernetes-example](https://gitlab.com/gitlab-examples/kubernetes-example)
+
+## [Configuring Bash Scripts](https://buildkite.com/docs/pipelines/writing-build-scripts)
+
+Bash scripts may continue on-error which is dangreours when using these `.sh` scripts for build, test or deploy activitie on any CI. When writing Bash shell scripts there are a number of options you can set to help prevent unexpected errors:
+
+| Switch     | Purpose                                                                     | Remarks                                |
+| :--------- | :-------------------------------------------------------------------------- | :------------------------------------- |
+| e          | Exit script immediately if any command returns a non-zero exit status.      | Without this script continues on error |
+| u          | Exit script immediately if an undefined variable is used                    | Sometimes not a liked behavior         |
+| o pipefail | Ensure Bash pipelines eturns if any cmd fail instead of last command status | At times required sudo                 |
+| x          | Expand and print each command before executing.                             | Rarely required                        |
+
+Thus one may have `set +Eeuox pipefail`, `set +Eeo pipefail`, `set +Ee`, or `set +Eeu` in their bash script to control errors returned.
+
+In next example capturing and returning status of intermediate method using `EXIT_STAT=$?`
+
+```
+#!/bin/bash
+
+# Note that we don't enable the 'e' option, which would cause the script to
+# immediately exit if 'run_tests' failed
+set -uo pipefail
+
+# Run the main command we're most interested in
+run_tests
+
+# Capture the exit status
+EXIT_STAT=$?
+
+# Run additional commands
+clean_up
+
+# Exit with the status of the original command
+exit $EXIT_STAT
+```
+
+## How Travis & Github Works ?
+
+- Travis builds a PR as soon as it is `OPENED` in `DRAFT` state as `merge-build`
+  - It keeps on re-building PRs as `merge-build` if new commits appear for PR fix
+  - Thus it's better to allow pull requests from `release/*` to be built
+  - User creates `release\*` gets build status and once done ready-to-merge
+- After allowing pull request, it may fail in master-merge or built after commit
+  - So you should never approve a failing build PR, take master update in PR (fix n commit)
+  - If master-merge is failing, you must take master update in `release/*` and fix release PR. Then either create new pull request or send email to admin to push current
+  - If master build is failing, somehow one has to notify and wait for revert last commit (no risk as deployments will not be made), or have a hotfix done. !!If master is failing everything is wrong!!
+
+## Pull-Requests (PRs) in Travis
+
+PR builds are an essential part of Gitflow. This is how travis handles them:
+
+### Build Strategy
+
+> - PRs in travis are always built as `merge-builds between source and upstream branch`. This is a good beahaviour.
+> - Travis builds PRs on `OPEN` automatically, thus `DRAFT` PRs are also built including `OPENED`. Should change this.
+> - Travis automatically merge-build `new commits that are added to PRs`, good for release branch edit till PR succeeds.
+
+### Double Builds
+
+You may've two builds in queue one for `branch-build` and another `merge-build` for PR. I don't see any reason to build branch seperately. Thus we can disable build of `release` branch provided it won't stop build of PRs (_from relese to master_). There is no harm if release branch is built (_releases are not frequent_)
+
+## Travis Dashboard Settings
+
+### Build Pushed Branches
+
+Obviously make this setting yes, everybody wants to buld branches as per strategy like `master`, `release/*`, `hotfix/*`. If ON, builds will be run on branches that are not explicitly excluded in your .travis.yml.
+
+### Build Pull-Requests
+
+If ON, builds will be run on new [pull requests](https://docs.travis-ci.com/user/pull-requests/). This is a desired behaviour for Gitflow.
+
+## Auto-Cancel Queued Builds
+
+Auto-cancel is required if you want travis to build only the latest commit saving resources
+
+### Branch Builds
+
+`Auto Cancel Branch Builds` if ON cancels queued builds for your branch, and appears in the build history. It's good not to build multiple pushes so turn it on.
+
+> Existing builds, if any will be allowed to finish
+
+### Pull-Request Builds
+
+Pull-request automatically builds on-creation as well as on-future-commit a merge of source and target branches in travis.
+
+This cancels queued builds for pull requests (the future merge result of your change/feature branch against its target) and appears in the Pull Requests tab of your repository.
+
+Thus, if this is disabled than travis will build new commits on a pull-request of release/\* branch keeping you updated. So after n-commits on release one can be comfortable to approve it.
+
+If you enable this future-commits of release/\* will not be built and merge-tested. So one will not be confident to merge request or not. In this case you've to create a new pull request to see if new commits are mergeable.
+
+## Skip Build for Any Commit
+
+Commit your code with message as `[skip <keyword>] ...` and travis will not built it. As **<keyword>** avaiable choices are: `ci`, `travis`, `travis ci`, `travis-ci`, or `travisci`.
+
+## Controlling Build Conditions ?
+
+Build conditions are entered in `.travis.yml` file which will be one of the deciding factors in determining that build will proceed or not apart from dashboard settings.
+
+For building conditions in `.travis.yml` two choices can be used: either with `only:/exclude:` based `string/regex` matching or logical `&& / ||` based `if:` conditions
+
+Inside `.travis.yml` these can be applied at 3 levels:
+
+- **File Level:** By using `branches: only:/except:` tag on top of `.travis.yml` conditions are applied to all stages and all jobs.
+- **Stage-Level:** Applies to all jobs inside (_jobs are parallel_). Two choices are there use `only:/exclude:` based regex conditions or use `if:` based logical conditions.
+- **Job-Level:**`: Applied to specific job, Two choices are there use`only:/exclude:`based regex conditions or use`if:` based logical conditions.
+
+### EX1: Programmatic Exiting Build
+
+```bashh
+    - stage: Prepare
+      script:
+      	- if [ "$TRAVIS_PULL_REQUEST" != "true" ]; then echo 'Not Allowed' && exit -100; fi
+      	- echo "Build State Continues ..."
+```
+
+### EX2: Using Only or Except
+
+Can use strings and reges
+
+```bash
+    - stage: Prepare
+      script:
+      	- echo "Build State Continues ..."
+      only:
+        - master
+        - /^hotfix*/
+        - ^[0-9]+\.[0-9]+\.[0-9]+$
+```
+
+## EX3: Using If (Logical Test)
+
+```
+    - stage: Deploy
+      script:
+      	- echo "Build State Continues ..."
+      if:
+      	- $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$
+      	- $TRAVIS_BRANCH =~ ^master|release|hotfix|quality$ || -n $TRAVIS_TAG
+      	- [ -n $TRAVIS_TAG ]
+
+```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,5 +16,8 @@ hello_world BuildSh
 #--- STEPS
 echo "Not doing anything just like that"
 
-echo "~~~ BUILD & TEST SUCCESFULL ~~~"
 echo "END  : Build Script"
+
+# Exporting function execution result to fnresult.txt (Unfortunately using EXIT_CODE=$? always makes EXIT_CODE=1
+# when returing to .travis.yml thus "if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi" command fails)
+echo "export EXIT_CODE=$?" > fnresult.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+##
+## Script for Prepare stage  [LINT, BUILD, GENERATE, TEST]
+##
+
+set -Eeo pipefail # (-) is enable (+) is disable
+
+echo "START: Build Script"
+
+# Sourcing & testing global library functions
+chmod 755 ./scripts/library.sh
+source ./scripts/library.sh
+echo "HELLO_VARIBLE: ${HELLO_VARIBLE}"
+hello_world BuildSh
+
+#--- STEPS
+echo "Not doing anything just like that"
+
+echo "~~~ BUILD & TEST SUCCESFULL ~~~"
+echo "END  : Build Script"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,5 +16,8 @@ hello_world DeploySh
 #--- STEPS
 echo "Not doing anything just like that"
 
-echo "~~~ TEST, DEPLOY & VERIFY SUCCESFULL ~~~"
 echo "END  : Deploy Script"
+
+# Exporting function execution result to fnresult.txt (Unfortunately using EXIT_CODE=$? always makes EXIT_CODE=1
+# when returing to .travis.yml thus "if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi" command fails)
+echo "export EXIT_CODE=$?" > fnresult.txt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+##
+## Script for Deploy stage [TEST-IMG, TEST-DEPLOY, DEPLOY & VERIFY]
+##
+
+set -Eeo pipefail # (-) is enable (+) is disable
+
+echo "START: Deploy Script"
+
+# Sourcing & testing global library functions
+chmod 755 ./scripts/library.sh
+source ./scripts/library.sh
+echo "HELLO_VARIBLE: ${HELLO_VARIBLE}"
+hello_world DeploySh
+
+#--- STEPS
+echo "Not doing anything just like that"
+
+echo "~~~ TEST, DEPLOY & VERIFY SUCCESFULL ~~~"
+echo "END  : Deploy Script"

--- a/scripts/env-init.sh
+++ b/scripts/env-init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+##
+## 1. This file is used to export enviornment variables not present in travis dashboard
+## - Must not have any secrets, better put them on travis dashbord or in .travi.yml using `travis encrypt`
+## - Advantage is that file remains in source control and can be used with any CI wihtout dashboard
+## - Just putting variables used in current travis dashboard for help (as comments)
+## - Advantage of putting them outside on dashbords is that your actual code can remain open source
+##   without you loosing your passwords
+##
+## - If you don't use export variables like `VAR=VALUE`, variables becomes local and lost once script
+##   caller is returned (Yuk)
+##
+## 2. This file also export a sample hello_world() method to let you know that things are working
+
+# Travis Dashboard Variables: F
+# export DKRHUB_USER="Dockerhub username here"
+# export DKRHUB_PASS="Dockerhub password here"
+# export DKRHUB_PROJ="Name of dockerhub project"
+# export DKRHUB_REPO="${DKRHUB_USER}/${DKRHUB_PROJ}""
+# export AUTH_EMAIL="Email of author for notifications"
+
+export HELLO_VARIABLE="! SACn Welcomes You [EnvVar]!"

--- a/scripts/env-init.sh
+++ b/scripts/env-init.sh
@@ -19,4 +19,4 @@
 # export DKRHUB_REPO="${DKRHUB_USER}/${DKRHUB_PROJ}""
 # export AUTH_EMAIL="Email of author for notifications"
 
-export HELLO_VARIABLE="! SACn Welcomes You [EnvVar]!"
+export HELLO_VARIABLE="! SACn Welcomes You [env-init.sh]!"

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -38,7 +38,7 @@ echo ""
 echo "------------------------------------------------------------------------------------------------------"
 # Is this a pull-request if so display it's number
 export IS_BRA_BLD=0
-if [ ${TRAVIS_PULL_REQUEST} != "false" ]
+if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]
 then
     export IS_PR_BLD=1
     echo "@@@ PR-Build# Yes, this build is for Pull-Request# ${TRAVIS_PULL_REQUEST}"
@@ -50,7 +50,7 @@ else
     echo "@@@ PR-Build# No, this build is NOT for Pull-Request"
 
     # Is this build for tag only (tag is set but no pull request)
-    if [ ${TRAVIS_TAG} != "" ]
+    if [[ ${TRAVIS_TAG} != "" ]]
     then
         export IS_TAG_BLD=1
         echo "@@@ Tag-Build# Yes, this build is for Tag# ${TRAVIS_TAG} on Branch# ${TRAVIS_BRANCH}"

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -50,7 +50,7 @@ else
     echo "@@@ PR-Build# No, this build is NOT for Pull-Request"
 
     # Is this build for tag only (tag is set but no pull request)
-    if [ ${TRAVIS_TAG} != "" ] ]
+    if [ ${TRAVIS_TAG} != "" ]
     then
         export IS_TAG_BLD=1
         echo "@@@ Tag-Build# Yes, this build is for Tag# ${TRAVIS_TAG} on Branch# ${TRAVIS_BRANCH}"

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -70,6 +70,9 @@ echo "--------------------------------------------------------------------------
 # lost when returing to .travis.yml)
 echo "export ENV_LOADED=1" > fnresult.txt
 
+# Adding information of docker enviornment (travis to file) - Non Blocking
+docker info > docker-info.txt || true
+
 # Exporting function execution result to fnresult.txt (Unfortunately using EXIT_CODE=$? always makes EXIT_CODE=1
 # when returing to .travis.yml thus "if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi" command fails)
 echo "export EXIT_CODE=$?" >> fnresult.txt

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+##
+## Script for printing enviornment information
+##
+
+set -Eeo pipefail # (-) is enable (+) is disable
+
+echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^TRAVIS CI ENVIORNMETN VARIABBLES^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+echo ""
+echo "BUILD ID   - ${TRAVIS_BUILD_ID}"
+echo "BUILD NO   - ${TRAVIS_BUILD_NUMBER}"
+echo "STAGE NAME - ${TRAVIS_BUILD_STAGE_NAME}"
+
+echo ""
+echo "JOB NAME - ${TRAVIS_JOB_NAME}"
+echo "JOB NO   - ${TRAVIS_JOB_NUMBER}"
+echo "JOB ID   - ${TRAVIS_JOB_ID}"
+
+echo ""
+echo "USER      - ${USER}"
+echo "HOME      - ${HOME}"
+echo "CURR DIR  - ${PWD}"
+echo "BUILD DIR - ${TRAVIS_BUILD_DIR}"
+echo "SUDO      - ${TRAVIS_SUDO}"
+
+echo ""
+echo "COMMIT ID (SHA)  - ${TRAVIS_COMMIT::8}"
+echo "COMMIT MESSAGE   - ${TRAVIS_COMMIT_MESSAGE::128}"
+echo "REPO SLUG        - ${TRAVIS_REPO_SLUG}"
+echo "BRANCH NAME      - ${TRAVIS_BRANCH}"
+echo "TAG NAME         - ${TRAVIS_TAG}"
+echo "PULL REQUEST ??  - ${TRAVIS_PULL_REQUEST}"
+echo "PULL REQUEST BR. - ${TRAVIS_PULL_REQUEST_BRANCH}"
+echo "PULL REQUEST SHA - ${TRAVIS_PULL_REQUEST_SHA::8}"
+
+# Is this request for branch only (no tags no pull requests)
+echo ""
+echo "------------------------------------------------------------------------------------------------------"
+# Is this a pull-request if so display it's number
+export IS_BRA_BLD=0
+if [ ${TRAVIS_PULL_REQUEST} != "false" ]
+then
+    export IS_PR_BLD=1
+    echo "@@@ PR-Build# Yes, this build is for Pull-Request# ${TRAVIS_PULL_REQUEST}"
+    echo "            # PR SOURCE: ${TRAVIS_PULL_REQUEST_BRANCH}, ${TRAVIS_PULL_REQUEST_SHA::8}"
+    echo "            # PR TARGET: ${TRAVIS_BRANCH}"
+    echo "            # PR MESAGE: ${TRAVIS_COMMIT_MESSAGE}"
+else
+    export IS_PR_BLD=0
+    echo "@@@ PR-Build# No, this build is NOT for Pull-Request"
+
+    # Is this build for tag only (tag is set but no pull request)
+    if [ ${TRAVIS_TAG} != "" ] ]
+    then
+        export IS_TAG_BLD=1
+        echo "@@@ Tag-Build# Yes, this build is for Tag# ${TRAVIS_TAG} on Branch# ${TRAVIS_BRANCH}"
+        export IS_BRA_BLD=0
+        echo "@@@ Branch-Build# No, this build is NOT for Branch"
+    else
+        export IS_TAG_BLD=0
+        echo "@@@ Tag-Build# No, this is NOT for Tag"
+        export IS_BRA_BLD=1
+        echo "@@@ Tag-Build# Yes, this build is for Branch# ${TRAVIS_BRANCH}"
+    fi
+fi
+
+# Exporting hello-world function
+hello_world() {
+    echo "Hello World"
+}
+export -f hello_world
+
+# Exporting dummy env. variable
+export ENV_LOADED=1
+
+echo "------------------------------------------------------------------------------------------------------"

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -44,7 +44,7 @@ then
     echo "@@@ PR-Build# Yes, this build is for Pull-Request# ${TRAVIS_PULL_REQUEST}"
     echo "            # PR SOURCE: ${TRAVIS_PULL_REQUEST_BRANCH}, ${TRAVIS_PULL_REQUEST_SHA::8}"
     echo "            # PR TARGET: ${TRAVIS_BRANCH}"
-    echo "            # PR MESAGE: ${TRAVIS_COMMIT_MESSAGE}"
+    echo "            # PR MESAGE: ${TRAVIS_COMMIT_MESSAGE::128}"
 else
     export IS_PR_BLD=0
     echo "@@@ PR-Build# No, this build is NOT for Pull-Request"

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -64,7 +64,12 @@ else
     fi
 fi
 
-# Exporting dummy env. variable
-export ENV_LOADED=1
-
 echo "------------------------------------------------------------------------------------------------------"
+
+# Exporting dummy env. variable (Using fnresult.txt instead of direct exports. As direct export will be
+# lost when returing to .travis.yml)
+echo "export ENV_LOADED=1" > fnresult.txt
+
+# Exporting function execution result to fnresult.txt (Unfortunately using EXIT_CODE=$? always makes EXIT_CODE=1
+# when returing to .travis.yml thus "if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi" command fails)
+echo "export EXIT_CODE=$?" >> fnresult.txt

--- a/scripts/envinfo.sh
+++ b/scripts/envinfo.sh
@@ -64,12 +64,6 @@ else
     fi
 fi
 
-# Exporting hello-world function
-hello_world() {
-    echo "Hello World"
-}
-export -f hello_world
-
 # Exporting dummy env. variable
 export ENV_LOADED=1
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+##
+## Library of exports and functions that can be used anywhere after sourcing the file
+
+# Exporting sample enviornment variable
+export HELLO_VARIBLE="! SACn Welcomes You [SharedEnvVar]!"
+
+# Exporting sample hello-world function
+hello_world() {
+    echo "Hello World"
+}
+export -f hello_world

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -2,6 +2,10 @@
 ##
 ## Library of exports and functions that can be used anywhere after sourcing the file
 
+# As this file will be sourced maybe in `.travis.yml` we can't use `set -e`
+# (Permamently Disabled Next Command)
+#set -Eeo pipefail # (-) is enable (+) is disable
+
 # Exporting sample enviornment variable
 export HELLO_VARIBLE="! SACn Welcomes You [SharedEnvVar]!"
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -7,10 +7,10 @@
 #set -Eeo pipefail # (-) is enable (+) is disable
 
 # Exporting sample enviornment variable
-export HELLO_VARIBLE="! SACn Welcomes You [SharedEnvVar]!"
+export HELLO_VARIABLE="! SACn Welcomes You [library.sh]!"
 
 # Exporting sample hello-world function
 hello_world() {
-    echo "Hello World"
+    echo "Hello World $1"
 }
 export -f hello_world

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set bash parameters: Exit on first error, etc.
-set -Eeo pipefail
+set -Eeo pipefail # (-) is enable (+) is disable
 
 # Welcome messge to be printed in the terminal.
 echo "!! Hello World !!"

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Set bash parameters: Exit on first error, etc.
+set -Eeo pipefail
+
+# Welcome messge to be printed in the terminal.
+echo "!! Hello World !!"
+
+# Loop to make sure that container keeps running.
+tail -f /dev/null


### PR DESCRIPTION
# 0.0.0 / 2019-12-13

Added code to generate docker image of **Ubuntu with essentials like git, rar etc.** including software like **docker, docker-compose, openssh, etc.**. Primary use is as a build-agent in CI's like Gitlab. Also this project may work as template for Gitflow based continuous deployment using Travis CI and Github. Revision 0.0.0 is an alpha, here no output will be generated. This is just to test iff Travis CI workflow with Gitlab is setup correctly or not as per: [docs/build-table.md](docs/build-table.md)

- ADD: Printing details of docker environment from `scripts\envinfo.sh` in file `docker-info.txt`
  - File content is displayed in `.travis.yml` for diagnostics of docker
- FIX: `.travis.yml` to check error code of bash scripts just after call
  - Using `EXIT_CODE=$?` with `if [[ $EXIT_CODE -ne 0 ]]; then set +e && exit $EXIT_CODE; fi` in `.travis.yml` does not work. Travis always makes `EXIT_CODE=1` on using `EXIT_CODE=$?` after call of bash script in `.travis.yml`
  - Now storing return status of function in file `fnresult.txt` using command `echo "export EXIT_CODE=$?" > fnresult.txt` and sourcing it in `.travis.yml` to get function results back
    - This is working fine, also pushed `export ENV_LOADED=1` to `fnresult.txt` for demonstration that environment variables can be exchanged via intermediate file from bash script to `.travis.yml`
- FIX: In `export HELLO_VARIABLE="! SACn Welcomes You [scripts\env-init.sh]!"` used name of file to differentiate from where this export is made. Also modified `hello_world` to print argument `$`
- FIX: Not using `if [[ ... ]]` for conditions in `./scripts/envinfo.sh`. Double brackets to be used everywhere
  - Inside `travis.yml` as well as any external script called like `./scripts/envinfo.sh`.
- FIX: Making all scripts executable was not using `*.sh` corrected as `chmod 755 ./scripts/*.sh` in `.travis.yml`
- ADD: File where file based environment variables can be placed for `source ./scripts/env-init.sh`
- FIX: As per common build errors in travis [my build fails unexpectedly](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly)
  - We can't use `set -e` either directly in your `.travis.yml`, or `sourceing` a script
  - Thus we've removed line `set -Eeo pipefail # (-) is enable (+) is disable`
  - Note that using set -e in external scripts does not cause this problem
  - Thus keeping line in `build.sh`, `deploy.sh`, but not in `library.sh` as this could be sources anywhere
- 000: Created basic 2 stage `.travis.yml` to simulate prepare and deploy.
  - This is a good starting point for first alpha release `0.0.0`
  - In `0.0.0` nothing will be built or deployed, just to test CI cycle
- MOV: Moved export of SHARED variables and functions from `envinfo.sh` to `library.sh`
- ADD: `docs/gitflow-guide.md` file for theory on Gitflow with `Quick CI Setup Checklist`
- MOD: `.travis.yml` with `os: linux`, `sudo: required`, `language: c` to make cfg complete
- MOD: `.travis.yml` with comments for env var needed in Travis Dashboard to run Project.
- MOD: README.md modified with quick links to important files like `.travis.yml`
- FTR: Added markdown in README.md for Travis build status of master branch on Github project
- FTR: Send email notifications to travis env var# `${AUTH_EMAIL}` in travis configuration
- FTR: Travis build-configuration conditions for Gtiflow model wrt simple 2 stage deployment
- ADD: Made History.md using `git changelog` and edited with details about next 0.0.0 version
- MOD: Description of project in README.md for next Alpha Version (0.0.0)
- ADD: Basic 2 stage travis configuration (.travis.yml) to print env vars using BASH script
- ADD: BASH script to print travis environment variables & export dummy data
- ADD: Vanilla ubuntu:1804 based docker image with `Hello World`
- ADD: CONTRIBUTING.md file for contributions making process for this repository.
- ADD: .gitignore file for arresting commit of windows, vscode and linux trash to git repo.
